### PR TITLE
Add LM model type and extended RC metrics

### DIFF
--- a/catwalk/dependencies/lm_eval/base.py
+++ b/catwalk/dependencies/lm_eval/base.py
@@ -610,6 +610,10 @@ class MultipleChoiceTask(Task):
 
         return lls
 
+    def unconditioned_prompt(self):
+        # Used in unconditioned scoring of answers for normalization
+        return "Answer:"
+
     def process_results(self, doc, results):
         gold = doc["gold"]
 

--- a/catwalk/dependencies/lm_eval/tasks/arc.py
+++ b/catwalk/dependencies/lm_eval/tasks/arc.py
@@ -99,6 +99,10 @@ class ARCEasyMC(ARCEasy):
         }
         return out_doc
 
+    def unconditioned_prompt(self):
+        # Don't need unconditioned normalization here
+        return None
+
 
 class ARCChallenge(ARCEasy):
     DATASET_PATH = "ai2_arc"

--- a/catwalk/metrics/__init__.py
+++ b/catwalk/metrics/__init__.py
@@ -1,3 +1,3 @@
 from catwalk.metrics.entropy import EntropyMetric
 from catwalk.metrics.perplexity import PerplexityMetric
-from catwalk.metrics.accuracy import AccuracyMetric, MultipleChoiceMetrics, RelativeAccuracyImprovementMetric
+from catwalk.metrics.accuracy import AccuracyMetric, RankedClassificationMetrics, RelativeAccuracyImprovementMetric

--- a/catwalk/metrics/__init__.py
+++ b/catwalk/metrics/__init__.py
@@ -1,4 +1,3 @@
 from catwalk.metrics.entropy import EntropyMetric
 from catwalk.metrics.perplexity import PerplexityMetric
-from catwalk.metrics.accuracy import AccuracyMetric
-from catwalk.metrics.accuracy import RelativeAccuracyImprovementMetric
+from catwalk.metrics.accuracy import AccuracyMetric, MultipleChoiceMetrics, RelativeAccuracyImprovementMetric

--- a/catwalk/metrics/accuracy.py
+++ b/catwalk/metrics/accuracy.py
@@ -40,7 +40,7 @@ class RelativeAccuracyImprovementMetric(AccuracyMetric):
         return (super().compute() - self.baseline) / self.baseline
 
 
-class MultipleChoiceMetrics():
+class RankedClassificationMetrics():
 
     # Tracks 4 different scoring possibilities for multiple-choice continuations:
     #   raw: Total probability of continuation

--- a/catwalk/metrics/accuracy.py
+++ b/catwalk/metrics/accuracy.py
@@ -1,5 +1,7 @@
 from typing import Union, List
 
+import math
+import numpy as np
 import torch
 from torchmetrics.aggregation import BaseAggregator
 
@@ -36,3 +38,67 @@ class RelativeAccuracyImprovementMetric(AccuracyMetric):
 
     def compute(self) -> torch.Tensor:
         return (super().compute() - self.baseline) / self.baseline
+
+
+class MultipleChoiceMetrics():
+
+    def __init__(self, primary_metric="acc_per_token"):
+        self.primary_metric = primary_metric
+        self.state = {"count": 0, "total_raw": 0, "total_per_token": 0,
+                      "total_per_char": 0, "total_uncond_norm": 0,
+                      "predicted_indices_raw": {},
+                      "predicted_indices_per_token": {},
+                      "predicted_indices_per_char": {},
+                      "total_probability_mass": 0}
+
+    def get_metrics(self, data):
+        logits = {"raw": [], "per_token": [], "per_char": []}
+        for prediction in data['model_output']:
+            logits["raw"].append(prediction['sum_logits'])
+            logits["per_token"].append(prediction['sum_logits'] / prediction['num_tokens'])
+            logits["per_char"].append(prediction['sum_logits'] / prediction['num_chars'])
+        gold_index = data["correct_choice"]
+        metrics = {}
+        for scoring in ["raw", "per_token", "per_char"]:
+            pred_index = int(np.argmax(logits[scoring]))  # int to avoid numpy numbers and keep tango happy
+            acc = 1 if pred_index == gold_index else 0
+            metrics[f"acc_{scoring}"] = acc
+            metrics[f"predicted_index_{scoring}"] = pred_index
+        metrics['probability_mass'] = sum(math.exp(logit) for logit in logits['raw'])
+        if self.primary_metric in metrics:
+            metrics['acc'] = metrics[self.primary_metric]
+        return metrics
+
+    def update(self, data):
+        metrics = data.get("metrics", self.get_metrics(data))
+        self.state['count'] += 1
+        for scoring in ["raw", "per_token", "per_char"]:
+            self.state[f'total_{scoring}'] += metrics[f'acc_{scoring}']
+            pred_index = metrics[f"predicted_index_{scoring}"]
+            index_tally = self.state[f'predicted_indices_{scoring}']
+            index_tally[pred_index] = index_tally.get(pred_index, 0) + 1
+        self.state["total_probability_mass"] += metrics['probability_mass']
+
+
+    def compute(self):
+        count = self.state['count']
+        if count == 0:
+            return {}
+        final_metrics = {}
+        for scoring in ["raw", "per_token", "per_char"]:
+            final_metrics[f"acc_{scoring}"] = self.state[f'total_{scoring}'] / count
+            index_tallies = []
+            for index, tally in self.state[f'predicted_indices_{scoring}'].items():
+                index_tallies.append((index, tally / count))
+            index_tallies.sort(key=lambda x: -x[1])
+            final_metrics[f'predicted_indices_{scoring}'] = index_tallies
+        final_metrics['avg_total_probability_mass'] = self.state["total_probability_mass"] / count
+        if self.primary_metric in final_metrics:
+            final_metrics['acc'] = final_metrics[self.primary_metric]
+        return final_metrics
+
+
+
+
+
+

--- a/catwalk/models/__init__.py
+++ b/catwalk/models/__init__.py
@@ -4,6 +4,7 @@ from catwalk.model import Model
 from catwalk.models.eleuther import EAIGPT, EAIT5
 from catwalk.models.gpt import GPTModel
 from catwalk.models.huggingface import HFAutoModel
+from catwalk.models.language_model import DecoderOnlyLanguageModel
 from catwalk.models.rank_classification import EncoderDecoderRCModel, DecoderOnlyRCModel
 from catwalk.models.t5 import T5Model, T5ModelFromPretrained
 from catwalk.models.metaicl import MetaICLModel
@@ -109,6 +110,7 @@ def add_decoder_only_model(name, hf_name, **kwargs):
     MODELS[name] = GPTModel(hf_name, **kwargs)
     MODELS[f"eai::{name}"] = EAIGPT(hf_name, **kwargs)
     MODELS[f"rc::{name}"] = DecoderOnlyRCModel(hf_name, **kwargs)
+    MODELS[f"lm::{name}"] = DecoderOnlyLanguageModel(hf_name, **kwargs)
     MODELS[f"metaicl::{name}"] = MetaICLModel(hf_name, **kwargs)
     MODELS[f"promptsource::{name}"] = PromptsourceDecoderOnlyRCModel(hf_name, **kwargs)
 

--- a/catwalk/models/language_model.py
+++ b/catwalk/models/language_model.py
@@ -1,0 +1,251 @@
+import collections
+import functools
+from typing import Dict, Any, List, Tuple, Sequence, Iterator, Union, Mapping, Optional, cast, Callable
+
+import more_itertools
+import torch
+from tango.common import Tqdm
+from torch import log_softmax
+from torch.nn.utils.rnn import pad_sequence
+from transformers import AutoModelForCausalLM, AutoModelForSeq2SeqLM, T5ForConditionalGeneration, GPT2LMHeadModel, \
+    AutoTokenizer, GPT2Tokenizer, T5TokenizerFast
+
+from catwalk import cached_transformers
+from catwalk.model import Model, TrainableModel, Instance
+from catwalk.task import Task, InstanceFormat, RankClassificationInstance
+
+_Model = Union[T5ForConditionalGeneration, GPT2LMHeadModel]
+_Tokenizer = Union[T5TokenizerFast, GPT2Tokenizer]
+
+
+class LanguageModel(Model):
+    VERSION = "002met"
+
+    def __init__(
+        self,
+        pretrained_model_name_or_path: str,
+        *,
+        pretrained_tokenizer_name_or_path: Optional[str] = None,
+        likelihood_averaging: str = 'token',
+        **model_kwargs
+    ):
+        """
+        # Parameters
+
+        pretrained_model_name_or_path : `str`
+            The name of the transformer, for example `"gpt2-large"`
+        likelihood_averaging : `str`, optional (default = `token`)
+            The method for averaging the sum likelihood of the continuation. 'char' averages by 
+            character length, 'token' averages by token length.
+        model_kwargs:
+            Additional kwargs passed to the `_make_model` method.
+        """
+        assert likelihood_averaging in {'char', 'token'}
+        self.pretrained_model_name_or_path = pretrained_model_name_or_path
+        if pretrained_tokenizer_name_or_path is None:
+            pretrained_tokenizer_name_or_path = pretrained_model_name_or_path
+        self.pretrained_tokenizer_name_or_path = pretrained_tokenizer_name_or_path
+
+        self.likelihood_averaging = likelihood_averaging
+        self.model_kwargs = model_kwargs
+
+    @classmethod
+    def _make_model(cls, pretrained_model_name_or_path: str, *, make_copy: bool = False, **kwargs) -> _Model:
+        raise NotImplementedError
+
+    def _make_tokenizer(self) -> AutoTokenizer:
+        return cached_transformers.get_tokenizer(AutoTokenizer, self.pretrained_tokenizer_name_or_path)
+
+    def predict(  # type: ignore
+        self,
+        task: Task,
+        instances: Sequence[Dict[str, Any]],
+        *,
+        batch_size: int = 32,
+        max_instances_in_memory: int = 32 * 1024,
+        num_shots: int = 0,
+        fewshot_seed: Optional[int] = None,
+        num_recorded_inputs: Optional[int] = 0,  # Number of instances to log in detail
+        unconditioned_prompt: Optional[str] = None, # Optional unconditioned prompt, e.g., "Answer:"
+    ) -> Iterator[Dict[str, Any]]:
+        model = self._make_model(
+            self.pretrained_model_name_or_path,
+            device_map="auto" if torch.cuda.device_count() > 0 else None,
+            **self.model_kwargs).eval()
+        tokenizer = self._make_tokenizer()
+
+        for instance_chunk in more_itertools.chunked(instances, max_instances_in_memory):
+            yield from self.predict_chunk(
+                task,
+                instance_chunk,
+                model,
+                tokenizer,
+                batch_size=batch_size,
+                num_shots=num_shots,
+                fewshot_seed=fewshot_seed,
+                num_recorded_inputs=num_recorded_inputs,
+                unconditioned_prompt=unconditioned_prompt
+            )
+
+    def predict_chunk(
+        self,
+        task: Task,
+        instances: Sequence[Dict[str, Any]],
+        model: _Model,
+        tokenizer: _Tokenizer,
+        batch_size: int = 32,
+        num_shots: int = 0,
+        fewshot_seed: Optional[int] = None,
+        num_recorded_inputs: Optional[int] = 0,
+        unconditioned_prompt: Optional[str] = None,
+    ) -> Iterator[Dict[str, Any]]:
+        instance_index_to_tuple_indices: Mapping[int, List[int]] = collections.defaultdict(list)
+        tuples: List[Tuple[str, str]] = []
+        rc_instances: List[RankClassificationInstance] = [
+            task.convert_instance(
+                instance,
+                InstanceFormat.RANK_CLASSIFICATION,
+                fewshot_instances=task.get_fewshot_instances(
+                    num_shots,
+                    random_seed=fewshot_seed if fewshot_seed is not None else i,
+                    exceptions=instance))
+            for i, instance in enumerate(instances)
+        ]
+
+        # get all the tuples
+        for instance_index, instance in enumerate(rc_instances):
+            for instance_request in instance.choices:
+                instance_index_to_tuple_indices[instance_index].append(len(tuples))
+                tuples.append(instance_request)
+        unconditioned_offset = len(tuples)
+        if unconditioned_prompt:
+            for instance_index, instance in enumerate(rc_instances):
+                for instance_request in instance.choices:
+                    tuples.append((unconditioned_prompt, instance_request[1]))
+
+        # run the requests
+        results = self._run_loglikelihood(tuples, model, tokenizer, batch_size)
+
+        # collect the results
+        for instance_index, instance in enumerate(rc_instances):
+            tuple_indices = instance_index_to_tuple_indices[instance_index]
+            results_for_instance = [results[i] for i in tuple_indices]
+            if unconditioned_prompt:
+                for idx, i in enumerate(tuple_indices):
+                    unconditioned_results = results[i + unconditioned_offset]
+                    results_for_instance[idx]['sum_logits_uncond'] = unconditioned_results['sum_logits']
+            res = {"model_output": results_for_instance, "correct_choice": instance.correct_choice}
+            if instance_index < num_recorded_inputs:
+                res["model_input"] = [tuples[i] for i in tuple_indices]
+                if unconditioned_prompt:
+                    res["unconditoned_input"] = [tuples[i + unconditioned_offset] for i in tuple_indices]
+            yield res
+
+    def _run_loglikelihood(
+        self,
+        tuples: Sequence[Tuple[str, str]],
+        model: _Model,
+        tokenizer: _Tokenizer,
+        batch_size: int = 32,
+    ) -> Sequence[float]:
+        raise NotImplementedError
+
+
+@Model.register("lm::decoder_only")
+class DecoderOnlyLanguageModel(LanguageModel):
+    @classmethod
+    def _make_model(
+        cls,
+        pretrained_model_name_or_path: str,
+        *,
+        make_copy: bool = False,
+        model_class: Any = AutoModelForCausalLM,
+        **kwargs
+    ) -> GPT2LMHeadModel:
+        return cached_transformers.get(
+            model_class,
+            pretrained_model_name_or_path,
+            make_copy=make_copy,
+            **kwargs)
+
+    @staticmethod
+    def _prefix_with_space(s: str) -> str:
+        if not s.startswith(' '):
+            return f" {s}"
+        else:
+            return s
+
+    def _run_loglikelihood(
+        self,
+        tuples: Sequence[Tuple[str, str]],
+        model: _Model,
+        tokenizer: _Tokenizer,
+        batch_size: int = 32,
+    ) -> Sequence[Dict]:
+        tokenized_contexts = tokenizer([t[0] for t in tuples], add_special_tokens=False)
+        tokenized_continuations = tokenizer([self._prefix_with_space(t[1]) for t in tuples], add_special_tokens=False)
+
+        # transpose the token ids so we can access them one instance at a time
+        cc_pairs: List[Dict[str, Tuple[torch.Tensor, torch.Tensor]]] = []
+        assert tokenized_contexts.keys() == tokenized_continuations.keys()
+        for field_name in tokenized_contexts.keys():
+            contexts = tokenized_contexts[field_name]
+            continuations = tokenized_continuations[field_name]
+            assert len(contexts) == len(continuations)
+            for i, (context, continuation) in enumerate(zip(contexts, continuations)):
+                if len(cc_pairs) <= i:
+                    cc_pairs.append({})
+                if len(context) == 0:
+                    context = [tokenizer.eos_token_id]
+                cc_pairs[i][field_name] = (
+                    torch.tensor(context, dtype=torch.long),
+                    torch.tensor(continuation, dtype=torch.long)
+                )
+
+        # find out the order to process sequences in
+        lengths = torch.tensor([
+            len(cc_pair["input_ids"][0]) + len(cc_pair["input_ids"][1])
+            for cc_pair in cc_pairs
+        ], dtype=torch.int)
+        ordered_indices = torch.argsort(lengths, descending=True)
+        del lengths
+
+        # actually do the processing
+        results: List[Optional[float]] = [None] * len(ordered_indices)
+        with torch.inference_mode():
+            with Tqdm.tqdm(ordered_indices, desc="Running log-likelihood queries") as ordered_indices_tqdm:
+                batches_of_indices = more_itertools.chunked(ordered_indices_tqdm, batch_size)
+                for batch_of_indices in batches_of_indices:
+                    unpadded_batch = collections.defaultdict(list)
+                    input_lengths = []
+                    batch_contexts = []
+                    batch_continuations = []
+                    for index in batch_of_indices:
+                        for field_name, (context_ids, continuation_ids) in cc_pairs[index].items():
+                            ids = torch.cat([context_ids, continuation_ids])
+                            if len(ids) > tokenizer.model_max_length+1:
+                                ids = ids[-(tokenizer.model_max_length+1):]
+                            ids = ids[:-1]
+                            unpadded_batch[field_name].append(ids)
+
+                        input_lengths.append(len(unpadded_batch["input_ids"][-1]))
+                        batch_contexts.append(cc_pairs[index]["input_ids"][0])
+                        batch_continuations.append(cc_pairs[index]["input_ids"][1])
+
+                    padded_batch = {
+                        field_name: pad_sequence(tensors, batch_first=True).to(model.device)
+                        for field_name, tensors in unpadded_batch.items()
+                    }
+
+                    batch_logits = log_softmax(model(**padded_batch)[0], dim=-1)
+                    z = zip(batch_of_indices, batch_logits, input_lengths, batch_contexts, batch_continuations)
+                    for i, instance_logits, input_length, instance_context, instance_continuation in z:
+                        instance_logits = instance_logits[input_length-len(instance_continuation):input_length]
+                        instance_logits = torch.gather(instance_logits, 1, instance_continuation.unsqueeze(-1).to(model.device))
+                        # denom = len(tuples[i][1]) if self.likelihood_averaging == 'char' else len(instance_continuation)
+                        results[i] = {"sum_logits": float(instance_logits.sum()), "num_tokens": len(tuples[i][1]),
+                                      "num_chars": len(instance_continuation)}
+                        # results[i] = float(instance_logits.sum()) / denom
+
+        assert None not in results
+        return results

--- a/catwalk/models/language_model.py
+++ b/catwalk/models/language_model.py
@@ -73,7 +73,10 @@ class LanguageModel(Model):
             self.pretrained_model_name_or_path,
             device_map="auto" if torch.cuda.device_count() > 0 else None,
             **self.model_kwargs).eval()
-        tokenizer = self._make_tokenizer()
+        if hasattr(model, "tokenizer"):
+            tokenizer = model.tokenizer
+        else:
+            tokenizer = self._make_tokenizer()
 
         for instance_chunk in more_itertools.chunked(instances, max_instances_in_memory):
             yield from self.predict_chunk(

--- a/catwalk/models/rank_classification.py
+++ b/catwalk/models/rank_classification.py
@@ -65,7 +65,7 @@ class RankClassificationModel(Model):
         max_instances_in_memory: int = 32 * 1024,
         num_shots: int = 0,
         fewshot_seed: Optional[int] = None,
-        num_model_inputs: Optional[int] = 0,  # Number of instances to log in detail
+        num_recorded_inputs: Optional[int] = 0,  # Number of instances to log in detail
     ) -> Iterator[Dict[str, Any]]:
         model = self._make_model(
             self.pretrained_model_name_or_path,
@@ -82,7 +82,7 @@ class RankClassificationModel(Model):
                 batch_size=batch_size,
                 num_shots=num_shots,
                 fewshot_seed=fewshot_seed,
-                num_model_inputs=num_model_inputs,
+                num_recorded_inputs=num_recorded_inputs,
             )
 
     def predict_chunk(
@@ -94,7 +94,7 @@ class RankClassificationModel(Model):
         batch_size: int = 32,
         num_shots: int = 0,
         fewshot_seed: Optional[int] = None,
-        num_model_inputs: Optional[int] = 0, # Number of model inputs to log in detail
+        num_recorded_inputs: Optional[int] = 0, # Number of model inputs to log in detail
     ) -> Iterator[Dict[str, Any]]:
         instance_index_to_tuple_indices: Mapping[int, List[int]] = collections.defaultdict(list)
         tuples: List[Tuple[str, str]] = []
@@ -125,7 +125,7 @@ class RankClassificationModel(Model):
             result_tensor = torch.tensor(results_for_instance)
             metric_args = (result_tensor, instance.correct_choice)
             prediction = {metric_name: metric_args for metric_name in task.metrics.keys()}
-            if instance_index >= num_model_inputs:
+            if instance_index >= num_recorded_inputs:
                 yield prediction
             else:
                 model_input = [tuples[i] for i in tuple_indices]

--- a/catwalk/run_eval.py
+++ b/catwalk/run_eval.py
@@ -22,7 +22,7 @@ _parser.add_argument('--fewshot_seed', type=int)
 _parser.add_argument('--limit', type=int)
 _parser.add_argument('--full_output_file', type=str, default=None, help="Filename for verbose output")
 _parser.add_argument('--metrics_file', type=str, default=None, help="Filename for metrics output")
-_parser.add_argument('--num_model_inputs', type=int, default=0, help="Number of sample model inputs in full output, for sanity checks")
+_parser.add_argument('--num_recorded_inputs', type=int, default=0, help="Number of sample model inputs in full output, for sanity checks")
 _parser.add_argument('-d', '-w', type=str, default=None, metavar="workspace", dest="workspace", help="the Tango workspace with the cache")
 
 
@@ -72,8 +72,8 @@ def main(args: argparse.Namespace):
         kwargs["num_shots"] = args.num_shots
     if args.fewshot_seed is not None:
         kwargs["fewshot_seed"] = args.fewshot_seed
-    if args.num_model_inputs:
-        kwargs["num_model_inputs"] = args.num_model_inputs
+    if args.num_recorded_inputs:
+        kwargs["num_recorded_inputs"] = args.num_recorded_inputs
     random_subsample_seed = None
 
     metric_task_dict = {}

--- a/catwalk/run_lm_eval.py
+++ b/catwalk/run_lm_eval.py
@@ -16,6 +16,10 @@ from catwalk.tasks.tasks_lm import TASKS_LM
 
 from catwalk.utils import guess_instance_id, sanitize, filter_dict_keys
 
+# Temporary workaround!
+import sys
+sys.path.append("/stage")
+
 # Catwalk eval script which is focused on LM models referenced on the fly
 
 _parser = argparse.ArgumentParser()

--- a/catwalk/run_lm_eval.py
+++ b/catwalk/run_lm_eval.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+import time
 
 from tango.common.logging import initialize_logging
 
@@ -28,7 +29,6 @@ _parser.add_argument('--limit', type=int, help="Max number of instances for a ta
 _parser.add_argument('--full_output_file', type=str, default=None, help="Filename for verbose output")
 _parser.add_argument('--metrics_file', type=str, default=None, help="Filename for metrics output")
 _parser.add_argument('--num_recorded_inputs', type=int, default=0, help="Number of sample model inputs in full output, for sanity checks")
-#_parser.add_argument('-d', '-w', type=str, default=None, metavar="workspace", dest="workspace", help="the Tango workspace with the cache")
 
 
 def main(args: argparse.Namespace):
@@ -115,12 +115,12 @@ def main(args: argparse.Namespace):
                 logger.info(f"Using unconditioned prompt for {task_name}: '{prompt}'")
                 task['unconditioned_prompt'] = prompt
 
-    metric_task_dict = {}
     verbose_output = []
 
     valid_model_args = ['split', 'limit', 'batch_size', 'num_shots',
                         'fewshot_seed', 'num_recorded_inputs', 'unconditioned_prompt']
     for task in tasks:
+        start_time = time.time()
         task_name = task['name']
         task_obj = task['task_obj']
         logger.info(f"Processing task: {task_name}")
@@ -139,7 +139,8 @@ def main(args: argparse.Namespace):
         output = {"task": task_name, "model": args.model,
                   "task_options": filter_dict_keys(task_dict, valid_model_args, remove_none=True),
                   "metrics": metrics,
-                  "num_instances": len(instances)}
+                  "num_instances": len(instances),
+                  "processing_time_seconds": time.time() - start_time}
         logger.info(f"Results from task {task_name}: {output}")
         per_instance = []
         for inst, p in zip(instances, predictions_updated):

--- a/catwalk/run_lm_eval.py
+++ b/catwalk/run_lm_eval.py
@@ -1,0 +1,184 @@
+import argparse
+import json
+import logging
+
+from tango.common.logging import initialize_logging
+
+from catwalk.dependencies.lm_eval.utils import simple_parse_args_string
+from catwalk.models import MODELS, add_decoder_only_model
+from catwalk.steps_simple import CalculateMetricsStep, PredictStep
+from catwalk.task import rc_metrics
+from catwalk.tasks import TASKS, TASK_SETS, get_instances
+from catwalk.tasks.tasks_lm import TASKS_LM
+
+from catwalk.utils import guess_instance_id, sanitize, filter_dict_keys
+
+# Catwalk eval script which is focused on LM models referenced on the fly
+
+_parser = argparse.ArgumentParser()
+_parser.add_argument('--model', type=str, required=True)
+_parser.add_argument('--task', type=str, nargs="+")
+_parser.add_argument('--task_file', type=str, help="Jsonl file with task specs")
+_parser.add_argument('--split', type=str, default="validation")
+_parser.add_argument('--batch_size', type=int, default=32)
+_parser.add_argument('--max_tokens_in_batch', type=int, help="Limit batch size to max tokens")
+_parser.add_argument('--num_shots', type=int, help="Number of examples in prompt")
+_parser.add_argument('--fewshot_seed', type=int, help="Random seed for picking prompt examples")
+_parser.add_argument('--limit', type=int, help="Max number of instances for a task")
+_parser.add_argument('--full_output_file', type=str, default=None, help="Filename for verbose output")
+_parser.add_argument('--metrics_file', type=str, default=None, help="Filename for metrics output")
+_parser.add_argument('--num_recorded_inputs', type=int, default=0, help="Number of sample model inputs in full output, for sanity checks")
+#_parser.add_argument('-d', '-w', type=str, default=None, metavar="workspace", dest="workspace", help="the Tango workspace with the cache")
+
+
+def main(args: argparse.Namespace):
+    initialize_logging(log_level="INFO")
+    logger = logging.getLogger()
+
+    #if args.workspace is None:
+    #    workspace = None
+    #else:
+    #    workspace = Workspace.from_url(args.workspace)
+
+    # Add arbitrary pretrained Huggingface models to MODELS on the fly
+    # TODO add support for model types other than decoder_only
+    if args.model not in MODELS:
+        prefix_split = args.model.split("::", 1)
+        model_name = prefix_split[-1]
+        # prefix = "" if len(prefix_split) == 1 else prefix_split[0]+"::"
+        model_args = simple_parse_args_string(model_name)
+        if 'pretrained' not in model_args:
+            raise ValueError(f"Unknown model {args.model}")
+        hf_name = model_args['pretrained']
+        del model_args['pretrained']
+        logger.info(f"Dynamically adding decoder-only models for: {model_name}")
+        add_decoder_only_model(model_name, hf_name, **model_args)
+        if args.model not in MODELS:
+            # Happens if prefix not present
+            raise ValueError(f"Unknown model {args.model}")
+
+    default_task_args = {"limit": args.limit if hasattr(args, "limit") else None}
+    default_task_args["split"] = args.split
+    default_task_args["batch_size"] = args.batch_size
+
+    if args.num_shots is not None:
+        default_task_args["num_shots"] = args.num_shots
+    if args.fewshot_seed is not None:
+        default_task_args["fewshot_seed"] = args.fewshot_seed
+    if args.num_recorded_inputs:
+        default_task_args["num_recorded_inputs"] = args.num_recorded_inputs
+
+    tasks = []
+    task_names = set()
+    if args.task_file:
+        with open(args.task_file, 'r') as file:
+            for line in file:
+                task_spec = json.loads(line.strip())
+                tasks.append(task_spec)
+                task_names.add(task_spec['name'])
+
+    if args.task:
+        for task in args.task:
+            if task in TASK_SETS:
+                raise ValueError("Task sets not supported!")
+            if task in task_names:
+                continue
+            task_names.add(task)
+            tasks.append({"name": task})
+
+    if not tasks:
+        raise ValueError("No tasks specified!")
+
+    # Normalize the tasks, check that they exist, etc
+    for task in tasks:
+        task_name = task['name']
+        if task_name not in TASKS and task_name not in TASKS_LM:
+            raise ValueError(f"Task name {task_name} not known!")
+        task_obj = TASKS_LM.get(task_name, TASKS[task_name])
+        task['task_obj'] = task_obj
+        if 'split' not in task and not default_task_args['split']:
+            task['split'] = task_obj.default_split
+        # TODO support various task construction overrides here?
+        # Hack to change MC accuracy metrics TODO Fix this!
+        if "relative_improvement" in task_obj.metrics or 'primary_metric' in task:
+            kwargs = {}
+            if 'primary_metric' in task:
+                kwargs['primary'] = task['primary_metric']
+                logger.info(f"Overriding metric for {task_name} with rc_metrics ({kwargs})")
+            else:
+                logger.warning(f"Overriding 'acc' metric for {task_name} with rc_metrics")
+            task_obj.metrics = {}
+            task_obj.add_metrics(rc_metrics(**kwargs))
+        if 'unconditioned_prompt' not in task:
+            if hasattr(task_obj, "inner_task") and hasattr(task_obj.inner_task, "unconditioned_prompt"):
+                prompt = task_obj.inner_task.unconditioned_prompt()
+                logger.info(f"Using unconditioned prompt for {task_name}: '{prompt}'")
+                task['unconditioned_prompt'] = prompt
+
+    metric_task_dict = {}
+    verbose_output = []
+
+    valid_model_args = ['split', 'limit', 'batch_size', 'num_shots',
+                        'fewshot_seed', 'num_recorded_inputs', 'unconditioned_prompt']
+    for task in tasks:
+        task_name = task['name']
+        task_obj = task['task_obj']
+        logger.info(f"Processing task: {task_name}")
+        task_dict = task.copy()
+        task_dict.update(default_task_args)
+        predictions = PredictStep().run(
+            model=MODELS[args.model],
+            task=task_obj,
+            **filter_dict_keys(task_dict, valid_model_args))
+        metrics, predictions_updated = CalculateMetricsStep().run(
+            model=MODELS[args.model],
+            task=task_obj,
+            predictions=predictions)
+        instances = get_instances(task_obj,
+                                  **filter_dict_keys(task_dict, ['split', 'limit', 'random_subsample_seed']))
+        output = {"task": task_name, "model": args.model,
+                  "task_options": filter_dict_keys(task_dict, valid_model_args, remove_none=True),
+                  "metrics": metrics,
+                  "num_instances": len(instances)}
+        logger.info(f"Results from task {task_name}: {output}")
+        per_instance = []
+        for inst, p in zip(instances, predictions_updated):
+            res1 = {"instance": guess_instance_id(inst), "prediction": p.get('prediction', p)}
+            if 'model_input' in p:
+                res1['model_input'] = p['model_input']
+            per_instance.append(res1)
+        output["per_instance"] = per_instance
+        if per_instance:
+            logger.info(f"First instance details for task {task_name}: {per_instance[0]}")
+        verbose_output.append(output)
+        if args.full_output_file:
+            logger.info(f"Saving full output in {args.full_output_file}...")
+            with open(args.full_output_file, 'w') as file:
+                for d in verbose_output:
+                    file.write(json.dumps(sanitize(d)) + "\n")
+
+    if args.metrics_file:
+        logger.info(f"Saving metrics in {args.metrics_file}...")
+        with open(args.metrics_file, 'w') as file:
+            for d in verbose_output:
+                del d['per_instance']  # Destructive
+            file.write(json.dumps(sanitize({"metrics": verbose_output})))
+
+    metrics_printed = []
+    for d in verbose_output:
+        metrics_printed.append(f" *** {d['task']} ***  (n = {d['num_instances']})  [{d['task_options']}]")
+        metrics = {}
+        # Code is a bit confused about nestedness of metrics
+        for metric_name, metric in d['metrics'].items():
+            if isinstance(metric, dict):
+                metrics.update(metric)
+            else:
+                metrics[metric_name] = metric
+        for metric_name, metric in metrics.items():
+            metrics_printed.append(f"    {metric_name}: {metric}")
+        metrics_printed.append("-----------------")
+    logger.info("Overall metrics:\n  " + "\n".join(metrics_printed))
+
+
+if __name__ == "__main__":
+    main(_parser.parse_args())

--- a/catwalk/run_lm_eval.py
+++ b/catwalk/run_lm_eval.py
@@ -16,10 +16,6 @@ from catwalk.tasks.tasks_lm import TASKS_LM
 
 from catwalk.utils import guess_instance_id, sanitize, filter_dict_keys
 
-# Temporary workaround!
-import sys
-sys.path.append("/stage")
-
 # Catwalk eval script which is focused on LM models referenced on the fly
 
 _parser = argparse.ArgumentParser()

--- a/catwalk/steps_simple.py
+++ b/catwalk/steps_simple.py
@@ -1,0 +1,37 @@
+from typing import (
+    Dict,
+    Any,
+    Optional,
+    Sequence,
+)
+
+from catwalk.task import Task
+from catwalk.tasks import get_instances
+from catwalk.model import Model
+
+class PredictStep():
+    def run(
+        self,
+        model: Model,
+        task: Task,
+        split: Optional[str] = None,
+        limit: Optional[int] = None,
+        random_subsample_seed: Optional[int] = None,
+        **kwargs
+    ) -> Sequence[Any]:
+        results = []
+        instances = get_instances(task, split, limit, random_subsample_seed)
+        for result in model.predict(task, instances, **kwargs):
+            results.append(result)
+        return results
+
+
+class CalculateMetricsStep():
+    def run(
+        self,
+        model: Model,
+        task: Task,
+        predictions: Sequence[Any]
+    ) -> Dict[str, float]:
+        metrics = model.calculate_metrics(task, predictions)
+        return metrics, predictions

--- a/catwalk/task.py
+++ b/catwalk/task.py
@@ -24,7 +24,6 @@ QA_METRICS = {
     "squad_metrics": torchmetrics.SQuAD,
 }
 
-
 try:
     from functools import cache as memoize  # type: ignore
 except ImportError:
@@ -37,7 +36,14 @@ except ImportError:
 def mc_metrics(num_classes: int):
     return {
         "acc": catwalk.metrics.AccuracyMetric,
-        # "relative_improvement": partial(catwalk.metrics.RelativeAccuracyImprovementMetric, num_classes=num_classes)
+        "relative_improvement": partial(catwalk.metrics.RelativeAccuracyImprovementMetric, num_classes=num_classes)
+    }
+
+@memoize
+def rc_metrics(primary="acc_per_token"):
+    return {
+        # This is a special type of metric which uses full prediction dict, not tensors
+        "mc_metrics": partial(catwalk.metrics.MultipleChoiceMetrics, primary_metric=primary)
     }
 
 
@@ -45,7 +51,7 @@ def mc_metrics(num_classes: int):
 def classification_metrics(num_classes: int):
     return {
         "acc": catwalk.metrics.AccuracyMetric,
-        # "relative_improvement": partial(catwalk.metrics.RelativeAccuracyImprovementMetric, num_classes=num_classes)
+        "relative_improvement": partial(catwalk.metrics.RelativeAccuracyImprovementMetric, num_classes=num_classes)
     }
 
 
@@ -71,7 +77,6 @@ class InstanceFormat(Enum):
 class RankClassificationInstance:
     choices: List[Tuple[str, str]]
     correct_choice: Optional[int]
-
 
 InstanceConversion = Union[Callable[[Dict[str, Any]], Any], Callable[[Dict[str, Any], KwArg()], Any]]
 

--- a/catwalk/task.py
+++ b/catwalk/task.py
@@ -43,7 +43,7 @@ def mc_metrics(num_classes: int):
 def rc_metrics(primary="acc_per_token"):
     return {
         # This is a special type of metric which uses full prediction dict, not tensors
-        "mc_metrics": partial(catwalk.metrics.MultipleChoiceMetrics, primary_metric=primary)
+        "rc_metrics": partial(catwalk.metrics.RankedClassificationMetrics, primary_metric=primary)
     }
 
 

--- a/catwalk/tasks/eleuther.py
+++ b/catwalk/tasks/eleuther.py
@@ -164,11 +164,15 @@ class EleutherClassificationTask(EleutherTask, WithAnswerOptionsMixin):
         *,
         answer_options: Sequence[str],
         version_override: Optional[str] = None,
+        metrics = None,
     ):
         EleutherTask.__init__(self, eleuther_task, version_override=version_override, ranked_classification=True)
         WithAnswerOptionsMixin.__init__(self, answer_options)
         self.add_instance_conversion(InstanceFormat.RANK_CLASSIFICATION, self.instance_as_rank_classification)
-        self.add_metrics(classification_metrics(len(answer_options)))
+        if not metrics:
+            self.add_metrics(classification_metrics(len(answer_options)))
+        else:
+            self.add_metrics(metrics)
 
     def instance_as_rank_classification(
         self,

--- a/catwalk/tasks/tasks_lm.py
+++ b/catwalk/tasks/tasks_lm.py
@@ -1,0 +1,57 @@
+from typing import Any, Dict, Optional, Sequence, Union
+
+import datasets
+from random import Random
+from torchmetrics import MeanMetric
+
+from catwalk.task import InstanceFormat, ENTAILMENT_METRICS, QA_METRICS, Task, \
+    classification_metrics, BINARY_CLASSIFICATION_METRICS, mc_metrics, rc_metrics, PERPLEXITY_METRICS
+from catwalk.tasks.eleuther import EleutherTask, RaceEleutherTask, EleutherTaskWithRenamedSplits, \
+    EleutherClassificationTask, EleutherClassificationTaskWithRenamedSplits
+from catwalk.tasks.huggingface import hfmc_conversion, HFDatasetsTask, hfqa_conversion, hfclassification_conversion
+from catwalk.tasks.p3 import P3Task
+from catwalk.tasks.raft import RaftTask
+from catwalk.tasks.metaicl import MetaICLTask
+from catwalk.tasks.mrqa import MrqaTask
+from catwalk.tasks.t5 import t5_prompt_conversion
+
+# Version of __init__.py defining TASKS_LM specifically for task variants geared towards LM type models
+# Usually will use TASKS from __init__.py as fallback
+
+TASKS_LM: Dict[str, Task] = {
+    "piqa": EleutherTask("piqa", ranked_classification=True).add_metrics(rc_metrics(primary="acc_per_token")),
+    "mrpc": EleutherClassificationTask("mrpc", answer_options=["no", "yes"], metrics=rc_metrics(primary="acc_raw")),
+    "qnli": EleutherClassificationTask("qnli", answer_options=["yes", "no"], metrics=rc_metrics(primary="acc_raw")),
+    "qqp": EleutherClassificationTask("qqp", answer_options=["no", "yes"], metrics=rc_metrics(primary="acc_raw")),
+    "sst": EleutherClassificationTask("sst", answer_options=["negative", "positive"], metrics=rc_metrics(primary="acc_raw")),
+    "rte": EleutherClassificationTask("rte", answer_options=["True", "False"], metrics=rc_metrics(primary="acc_raw")),
+    "wnli": EleutherTask("wnli", ranked_classification=True).add_metrics(rc_metrics(primary="acc_raw")),
+    "boolq": EleutherTask("boolq", ranked_classification=True).add_metrics(rc_metrics(primary="acc_raw")),
+    "copa": EleutherTask("copa", ranked_classification=True).add_metrics(rc_metrics(primary="acc_raw")),
+    "wic": EleutherTask("wic", ranked_classification=True).add_metrics(rc_metrics(primary="acc_raw")),
+    "wsc": EleutherTask(
+        "wsc",
+        ranked_classification=True,
+        promptsource_task_spec=('super_glue', 'wsc.fixed')
+    ).add_metrics(rc_metrics(primary="acc_raw")),
+    # "drop": EleutherTask("drop").add_metrics(QA_METRICS),
+    # "lambada": EleutherTask("lambada_standard").add_metrics(PERPLEXITY_METRICS).add_metric("acc", MeanMetric),
+    # "pubmedqa": EleutherTaskWithRenamedSplits("pubmedqa").add_metrics(BINARY_CLASSIFICATION_METRICS),
+    "sciq": EleutherTask("sciq", ranked_classification=True).add_metrics(rc_metrics(primary="acc_raw")),
+    #"triviaqa": EleutherTask(
+    #    "triviaqa",
+    #    promptsource_task_spec=("trivia_qa", "unfiltered")
+    #).add_metrics(QA_METRICS),
+    "arc_easy": EleutherTask("arc_easy", ranked_classification=True).add_metrics(rc_metrics(primary="acc_uncond")),
+    "arc_easy:mc": EleutherTask("arc_easy:mc", ranked_classification=True).add_metrics(rc_metrics(primary="acc_raw")),
+    "arc_challenge": EleutherTask("arc_challenge", ranked_classification=True).add_metrics(rc_metrics(primary="acc_uncond")),
+    "arc_challenge:mc": EleutherTask("arc_challenge:mc", ranked_classification=True).add_metrics(rc_metrics(primary="acc_raw")),
+    # For logiqa the answer choices are shown, but full answer string, so trying acc_raw here
+    "logiqa": EleutherTask("logiqa", ranked_classification=True).add_metrics(rc_metrics(primary="acc_raw")),
+    "hellaswag": EleutherTask("hellaswag", ranked_classification=True).add_metrics(rc_metrics(primary="acc_per_token")),
+    "openbookqa": EleutherTask("openbookqa", ranked_classification=True).add_metrics(rc_metrics(primary="acc_uncond")),
+    "headqa_en": EleutherTask("headqa_en", ranked_classification=True)  .add_metrics(rc_metrics(primary="acc_uncond")),
+    "mathqa": EleutherTask("mathqa", ranked_classification=True).add_metrics(rc_metrics(primary="acc_per_token")),
+    #"wsc273": EleutherTask("wsc273", ranked_classification=True).add_metrics(ENTAILMENT_METRICS),
+    "winogrande": EleutherTask("winogrande", ranked_classification=True).add_metrics(rc_metrics(primary="acc_per_token")),
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 torch>=2.0
-ai2-tango[torch,transformers,beaker,wandb]>=1.1
 #ai2-tango[torch,transformers,fairscale,beaker,wandb]>=1.1
-#ai2-tango[torch,transformers,fairscale,beaker,wandb] @ git+https://github.com/allenai/tango.git@main
+ai2-tango[torch,transformers,fairscale,beaker,wandb] @ git+https://github.com/allenai/tango.git@main
 
 # Sometimes you want to insist on the latest beaker-py.
 # Uncomment the following if you do.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+torch>=2.0
 ai2-tango[torch,transformers,fairscale,beaker,wandb]>=1.1
 #ai2-tango[torch,transformers,fairscale,beaker,wandb] @ git+https://github.com/allenai/tango.git@main
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 torch>=2.0
-ai2-tango[torch,transformers,fairscale,beaker,wandb]>=1.1
+ai2-tango[torch,transformers,beaker,wandb]>=1.1
+#ai2-tango[torch,transformers,fairscale,beaker,wandb]>=1.1
 #ai2-tango[torch,transformers,fairscale,beaker,wandb] @ git+https://github.com/allenai/tango.git@main
 
 # Sometimes you want to insist on the latest beaker-py.


### PR DESCRIPTION
Included new features :
  * multi-faceted ranked-classification scoring (including normalized by unconditional probability)
  * loading of custom non-HF models (by injecting class through a string input)
  * new "lm::" class of models (will add more modes to this later)
  * max_batch_tokens setting (to avoid having to worry about batch size vs task)
  * configure options per task (such as num_shots and limit) through a task input file
  * record number of tokens in metrics
  * uses simplified (non-tango) steps
