### PR TITLE
Add perplexity evaluations to lm:: model

### DIFF
--- a/catwalk/metrics/__init__.py
+++ b/catwalk/metrics/__init__.py
@@ -1,3 +1,3 @@
 from catwalk.metrics.entropy import EntropyMetric
-from catwalk.metrics.perplexity import PerplexityMetric
+from catwalk.metrics.perplexity import PerplexityMetric, PerplexityMetrics
 from catwalk.metrics.accuracy import AccuracyMetric, RankedClassificationMetrics, RelativeAccuracyImprovementMetric

--- a/catwalk/models/eleuther.py
+++ b/catwalk/models/eleuther.py
@@ -8,7 +8,7 @@ from tango.common import Tqdm
 from tango.integrations.torch.util import resolve_device
 from torch import log_softmax
 from torch.nn.utils.rnn import pad_sequence
-from transformers import AutoModelForCausalLM, GPT2Tokenizer, GPT2LMHeadModel, \
+from transformers import AutoModelForCausalLM, AutoTokenizer, GPT2Tokenizer, GPT2LMHeadModel, \
     AutoModelForSeq2SeqLM, T5ForConditionalGeneration, T5TokenizerFast
 
 from catwalk import cached_transformers
@@ -38,7 +38,8 @@ class EAIGPT(Model):
         batch_size: int = 32,
         max_instances_in_memory: int = 16 * 1024,
         max_gen_toks: int = 256,
-        num_shots: int = 0
+        num_shots: int = 0,
+        **kwargs
     ) -> Iterator[Dict[str, Any]]:
         model = cached_transformers.get(
             AutoModelForCausalLM,
@@ -47,7 +48,7 @@ class EAIGPT(Model):
             device_map="auto" if torch.cuda.device_count() > 0 else None,
             **self.model_kwargs,
         ).eval()
-        tokenizer = cached_transformers.get_tokenizer(GPT2Tokenizer, self.pretrained_model_name_or_path)
+        tokenizer = cached_transformers.get_tokenizer(AutoTokenizer, self.pretrained_model_name_or_path)
 
         for instance_chunk in more_itertools.chunked(instances, max_instances_in_memory):
             yield from self.predict_chunk(

--- a/catwalk/run_lm_eval.py
+++ b/catwalk/run_lm_eval.py
@@ -135,13 +135,14 @@ def main(args: argparse.Namespace):
 
     # Initial loading of model done here for early failures and overrides if needed
     model_obj = MODELS[args.model]
-    logger.info("Loading model...")
-    model_cached = model_obj._make_model(
-        model_obj.pretrained_model_name_or_path,
-        device_map="auto" if torch.cuda.device_count() > 0 else None,
-        **model_obj.model_kwargs).eval()
-    if not hasattr(model_cached, "tokenizer"):
-        tokenizer_cached = model_obj._make_tokenizer()
+    if hasattr(model_obj, "_make_model"):
+        logger.info("Loading model...")
+        model_cached = model_obj._make_model(
+            model_obj.pretrained_model_name_or_path,
+            device_map="auto" if torch.cuda.device_count() > 0 else None,
+            **model_obj.model_kwargs).eval()
+        if not hasattr(model_cached, "tokenizer"):
+            tokenizer_cached = model_obj._make_tokenizer()
 
     valid_model_args = ['split', 'limit', 'batch_size', 'max_batch_tokens', 'num_shots', 'model_max_length',
                         'fewshot_seed', 'num_recorded_inputs', 'unconditioned_prompt']
@@ -170,7 +171,7 @@ def main(args: argparse.Namespace):
         logger.info(f"Results from task {task_name}: {output}")
         per_instance = []
         for inst, p in zip(instances, predictions_updated):
-            res1 = {"instance": guess_instance_id(inst), "prediction": p.get('prediction', p)}
+            res1 = {"instance": guess_instance_id(inst, idx=len(per_instance)), "prediction": p.get('prediction', p)}
             if 'model_input' in p:
                 res1['model_input'] = p['model_input']
             per_instance.append(res1)

--- a/catwalk/task.py
+++ b/catwalk/task.py
@@ -46,6 +46,13 @@ def rc_metrics(primary="acc_per_token"):
         "rc_metrics": partial(catwalk.metrics.RankedClassificationMetrics, primary_metric=primary)
     }
 
+@memoize
+def ppl_metrics(primary="ppl_token"):
+    return {
+        # This is a special type of metric which uses full prediction dict, not tensors
+        "ppl_metrics": partial(catwalk.metrics.PerplexityMetrics, primary_metric=primary)
+    }
+
 
 @memoize
 def classification_metrics(num_classes: int):

--- a/catwalk/tasks/tasks_lm.py
+++ b/catwalk/tasks/tasks_lm.py
@@ -5,7 +5,7 @@ from random import Random
 from torchmetrics import MeanMetric
 
 from catwalk.task import InstanceFormat, ENTAILMENT_METRICS, QA_METRICS, Task, \
-    classification_metrics, BINARY_CLASSIFICATION_METRICS, mc_metrics, rc_metrics, PERPLEXITY_METRICS
+    classification_metrics, BINARY_CLASSIFICATION_METRICS, mc_metrics, rc_metrics, ppl_metrics, PERPLEXITY_METRICS
 from catwalk.tasks.eleuther import EleutherTask, RaceEleutherTask, EleutherTaskWithRenamedSplits, \
     EleutherClassificationTask, EleutherClassificationTaskWithRenamedSplits
 from catwalk.tasks.huggingface import hfmc_conversion, HFDatasetsTask, hfqa_conversion, hfclassification_conversion
@@ -19,6 +19,7 @@ from catwalk.tasks.t5 import t5_prompt_conversion
 # Usually will use TASKS from __init__.py as fallback
 
 TASKS_LM: Dict[str, Task] = {
+    "wikitext": EleutherTask("wikitext").add_metrics(ppl_metrics(primary="ppl_token")),
     "piqa": EleutherTask("piqa", ranked_classification=True).add_metrics(rc_metrics(primary="acc_per_token")),
     "mrpc": EleutherClassificationTask("mrpc", answer_options=["no", "yes"], metrics=rc_metrics(primary="acc_raw")),
     "qnli": EleutherClassificationTask("qnli", answer_options=["yes", "no"], metrics=rc_metrics(primary="acc_raw")),

--- a/catwalk/utils.py
+++ b/catwalk/utils.py
@@ -45,13 +45,15 @@ def sanitize(x: Any) -> Any:
             "that returns a JSON-like object.")
 
 
-def guess_instance_id(instance, max_val_length=30):
+def guess_instance_id(instance, max_val_length=30, idx=None):
     for key in ['id', 'qid', 'q_id', 'line', 'identifier']:
         if key in instance:
             return {key: instance[key]}
     for key, value in instance.items():
         if isinstance(value, str) and len(value) <= max_val_length:
             return {key: value}
+    if idx is not None:
+        return {"instance_idx": idx}
     return {"id": "NA"}
 
 


### PR DESCRIPTION
Sample use case (important to remember `model_max_length` if it's not implicitly defined):
```
python catwalk/run_lm_eval.py  --model lm::pretrained=EleutherAI/pythia-160m,revision=step140000  \
--task wikitext --split validation  --full_output_file output.jsonl --metrics_file metrics.json \
--limit 10 --model_max_length 2048 --num_recorded_inputs 1
```
Should produce something like:
```
[05/09/23 16:36:01] INFO     Saving full output in output.jsonl...                                                                                                                                run_lm_eval.py:183
[05/09/23 16:36:01] INFO     Saving metrics in metrics.json...                                                                                                                                    run_lm_eval.py:189
[05/09/23 16:36:01] INFO     Overall metrics:
   *** wikitext ***  (n = 10)  [{'limit': 10, 'split': 'validation', 'batch_size': 32, 'model_max_length': 2048, 'num_recorded_inputs': 1}]
    bits_per_byte: 1.0092688034671544
    ppl_token: 22.99070712943112
    ppl_char: 2.014633350085475
    ppl_word: 40.62550828607829
    ppl_byte: 2.0128906545809406
    primary_metric: ppl_token
    total_tokens_input: 45311
    max_token_count: 14343
    ppl_primary: 22.99070712943112
```