### PR TITLE
Add generic perplexity task

### DIFF
--- a/catwalk/metrics/perplexity.py
+++ b/catwalk/metrics/perplexity.py
@@ -79,6 +79,8 @@ class PerplexityMetrics():
         final_metrics['primary_metric'] = self.primary_metric
         final_metrics['total_tokens_input'] = self.state['total_tokens_input']
         final_metrics['max_token_count'] = self.state['max_token_count']
+        final_metrics['num_instances'] = count
+        final_metrics['total_tokens'] = self.state['total_tokens']
         if self.primary_metric in final_metrics:
             final_metrics['ppl_primary'] = final_metrics[self.primary_metric]
         return final_metrics

--- a/catwalk/run_lm_eval.py
+++ b/catwalk/run_lm_eval.py
@@ -108,9 +108,18 @@ def main(args: argparse.Namespace):
     # Normalize the tasks, check that they exist, etc
     for task in tasks:
         task_name = task['name']
-        if task_name not in TASKS and task_name not in TASKS_LM:
+        if task_name in TASKS_LM:
+            task_obj = TASKS_LM[task_name]
+        elif task_name in TASKS:
+            task_obj = TASKS[task_name]
+        else:
             raise ValueError(f"Task name {task_name} not known!")
-        task_obj = TASKS_LM.get(task_name, TASKS[task_name])
+        if "task_options" in task:
+            if not hasattr(task_obj, "clone"):
+                raise ValueError("Cannot specify task_options for this task")
+            task_obj = task_obj.clone(**task['task_options'])
+        if "task_rename" in task:
+            task['name'] = task_name = task["task_rename"]
         task['task_obj'] = task_obj
         if 'split' not in task and not default_task_args['split']:
             task['split'] = task_obj.default_split

--- a/catwalk/tasks/perplexity_jsonl.py
+++ b/catwalk/tasks/perplexity_jsonl.py
@@ -6,6 +6,8 @@ import json
 from catwalk.task import Task, InstanceFormat
 from cached_path import cached_path
 
+# Task for evaluating a generic set of files (or URLs) on perplexity metrics
+
 class PerplexityJsonLTask(Task):
     def __init__(
         self,

--- a/catwalk/tasks/perplexity_jsonl.py
+++ b/catwalk/tasks/perplexity_jsonl.py
@@ -1,0 +1,53 @@
+from typing import Dict, Any, Sequence
+from copy import deepcopy
+import gzip
+import json
+
+from catwalk.task import Task, InstanceFormat
+from cached_path import cached_path
+
+class PerplexityJsonLTask(Task):
+    def __init__(
+        self,
+        files=None  # files (or URLs) to be used
+    ):
+        Task.__init__(self)
+        self.files = files
+        self._cached_paths = None
+        self._cache_dir = None   # Can override cache dir
+        self.add_instance_conversion(InstanceFormat.ELEUTHER_DOC, self.instance_as_eleuther_doc)
+
+    def clone(self, files):
+        new_task = deepcopy(self)
+        new_task.files = files
+        return new_task
+
+    def has_split(self, split: str) -> bool:
+        return True  # Assume the files are for the requested split
+
+    def cached_paths(self):
+        if self._cached_paths is None:
+            self._cached_paths = []
+            for file in self.files:
+                self._cached_paths.append((file, cached_path(file, cache_dir=self._cache_dir)))
+        return self._cached_paths
+
+    def get_split(self, split: str) -> Sequence[Dict[str, Any]]:
+        instances = []
+        for (orig_file, cache_file) in self.cached_paths():
+            if orig_file.endswith('.gz'):
+                with gzip.open(cache_file, 'r') as file:
+                    for line in file:
+                        instances.append(json.loads(line.decode("utf-8").strip()))
+            else:
+                with open(cache_file, 'r') as file:
+                    for line in file:
+                        instances.append(json.loads(line.strip()))
+        return instances
+
+    def instance_as_eleuther_doc(self, instance):
+        return instance.get('text', instance.get('doc'))
+
+    @property
+    def default_split(self) -> str:
+        return "validation"

--- a/catwalk/tasks/tasks_lm.py
+++ b/catwalk/tasks/tasks_lm.py
@@ -8,6 +8,7 @@ from catwalk.task import InstanceFormat, ENTAILMENT_METRICS, QA_METRICS, Task, \
     classification_metrics, BINARY_CLASSIFICATION_METRICS, mc_metrics, rc_metrics, ppl_metrics, PERPLEXITY_METRICS
 from catwalk.tasks.eleuther import EleutherTask, RaceEleutherTask, EleutherTaskWithRenamedSplits, \
     EleutherClassificationTask, EleutherClassificationTaskWithRenamedSplits
+from catwalk.tasks.perplexity_jsonl import PerplexityJsonLTask
 from catwalk.tasks.huggingface import hfmc_conversion, HFDatasetsTask, hfqa_conversion, hfclassification_conversion
 from catwalk.tasks.p3 import P3Task
 from catwalk.tasks.raft import RaftTask
@@ -19,6 +20,7 @@ from catwalk.tasks.t5 import t5_prompt_conversion
 # Usually will use TASKS from __init__.py as fallback
 
 TASKS_LM: Dict[str, Task] = {
+    "ppl_custom": PerplexityJsonLTask().add_metrics(ppl_metrics(primary="ppl_token")),
     "wikitext": EleutherTask("wikitext").add_metrics(ppl_metrics(primary="ppl_token")),
     "piqa": EleutherTask("piqa", ranked_classification=True).add_metrics(rc_metrics(primary="acc_per_token")),
     "mrpc": EleutherClassificationTask("mrpc", answer_options=["no", "yes"], metrics=rc_metrics(primary="acc_raw")),


### PR DESCRIPTION
This adds PerplexityJsonLTask for specifying generic perplexity tasks against a set of .jsonl or .jsonl.gz files. Here's an example of usage:

```
 python catwalk/run_lm_eval.py  --model lm::pretrained=EleutherAI/pythia-160m,revision=step140000  --task_file eval-suite.jsonl --split validation  --full_output_file output.jsonl --metrics_file metrics.json --limit 10 --num_recorded_inputs 1 --batch_size 4 --model_max_length 2048
```

where eval-suite.jsonl could be something like
```
{"name": "ppl_custom", "split": "validation", "task_options": {"files": ["s3://path/to/file1", "s3://path/to/file2"]}, "task_rename": "ppl_c4"}
{"name": "arc_easy", "split": "validation"}
```