### PR TITLE
Add EAI metrics and generation in lm:: tasks

### DIFF
--- a/catwalk/metrics/__init__.py
+++ b/catwalk/metrics/__init__.py
@@ -1,3 +1,4 @@
+from catwalk.metrics.eleuther_metrics import EleutherMetrics
 from catwalk.metrics.entropy import EntropyMetric
 from catwalk.metrics.perplexity import PerplexityMetric, PerplexityMetrics
 from catwalk.metrics.accuracy import AccuracyMetric, RankedClassificationMetrics, RelativeAccuracyImprovementMetric

--- a/catwalk/metrics/eleuther_metrics.py
+++ b/catwalk/metrics/eleuther_metrics.py
@@ -1,0 +1,21 @@
+class EleutherMetrics():
+
+    # Use directly metrics from Eleuther task
+    def __init__(self, inner_task):
+        self.inner_task = inner_task
+        self.predictions = []
+
+    def get_metrics(self, data):
+        # Metrics are already calculated at instance level
+        return data['metrics']
+
+    def update(self, data):
+        self.predictions.append(data['metrics'])
+
+    def compute(self):
+
+        metrics = {
+            key: fn([p[key] for p in self.predictions])
+            for key, fn in self.inner_task.aggregation().items()
+        }
+        return metrics

--- a/catwalk/model.py
+++ b/catwalk/model.py
@@ -66,9 +66,9 @@ class Model(Registrable, DetHashWithVersion, ABC):
             for prediction in predictions_tqdm:
                 # For models proving model_output (LM models), the metric is called directly
                 if 'model_output' in prediction:
-                    prediction['metrics'] = {}
+                    prediction['metrics'] = prediction.get("metrics", {})
                     for metric_name, metric in metrics.items():
-                        # We'll update the prediction with its individual metrics
+                        # We'll update the prediction with its individual metrics if need be
                         try:
                             prediction['metrics'].update(metric.get_metrics(prediction))
                         except:

--- a/catwalk/tasks/tasks_lm.py
+++ b/catwalk/tasks/tasks_lm.py
@@ -20,6 +20,8 @@ from catwalk.tasks.t5 import t5_prompt_conversion
 # Usually will use TASKS from __init__.py as fallback
 
 TASKS_LM: Dict[str, Task] = {
+    "squad2": EleutherTask("squad2", eleuther_metrics=True),
+    "drop": EleutherTask("drop", eleuther_metrics=True),
     "ppl_custom": PerplexityJsonLTask().add_metrics(ppl_metrics(primary="ppl_token")),
     "wikitext": EleutherTask("wikitext").add_metrics(ppl_metrics(primary="ppl_token")),
     "piqa": EleutherTask("piqa", ranked_classification=True).add_metrics(rc_metrics(primary="acc_per_token")),


### PR DESCRIPTION
This adds support for Eleuther-style "greedy_until" as well as "mixed" tasks (such as SQuAD 2 which both generates an answer and also scores a special "unanswerable" answer to see if it's > 0.5).

Example input:
```
python catwalk/run_lm_eval.py  --model lm::pretrained=EleutherAI/pythia-160m,revision=step140000  \
--task drop squad2 --split validation  --full_output_file output.jsonl --metrics_file metrics.json \
--limit 5 --num_recorded_inputs 1 --model_max_length 1024  --num_shots 3
```
which should produce a metrics.json similar to:
```
{"metrics": [{"task": "drop", "model": "lm::pretrained=EleutherAI/pythia-160m,revision=step140000", 
"task_options": {"limit": 5, "split": "validation", "batch_size": 32, "model_max_length": 1024, "num_shots": 3, "num_recorded_inputs": 1}, 
"metrics": {"eleuther_metrics": {"em": 0.0, "f1": 0.0}}, "num_instances": 5, "processing_time_seconds": 8.896850109100342}, 
{"task": "squad2", "model": "lm::pretrained=EleutherAI/pythia-160m,revision=step140000", 
"task_options": {"limit": 5, "split": "validation", "batch_size": 32, "model_max_length": 1024, "num_shots": 3, "num_recorded_inputs": 1}, 
"metrics": {"eleuther_metrics": {"exact": 0.0, "f1": 0.6857142857142856, "HasAns_exact": 0.0, "HasAns_f1": 0.6857142857142856, "NoAns_exact": 0, "NoAns_f1": 0, "best_exact": 0.0, "best_f1": 0.6857142857142856}}, "num_instances": 5, "processing_time_seconds": 31.584840297698975}]}
```

